### PR TITLE
Remove dependency to hash-strings.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -471,7 +471,7 @@ export class EqualityMap<K, V> {
     }
 
     *values(): IterableIterator<V> {
-        for (const [_h, [_k, v]] of this._map) {
+        for (const [, [, v]] of this._map) {
             yield v;
         }
     }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,15 @@
-import stringHash = require("string-hash");
-
 export const hashCodeInit = 17;
+
+// This function based on Java's string hashing.
+export function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const chr = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + chr;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return hash;
+}
 
 export function addHashCode(acc: number, h: number): number {
     return (acc * 31 + (h | 0)) | 0;
@@ -511,7 +520,7 @@ export function areEqual(a: any, b: any): boolean {
 
 export function hashCodeOf(x: any): number {
     if (typeof x === "number") return x | 0;
-    if (typeof x === "string") return stringHash(x);
+    if (typeof x === "string") return hashString(x);
 
     let h = hashCodeInit;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "collection-utils",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
         "tslint": "^5.10.0",
         "typescript": "^2.8.3"
     },
-    "dependencies": {
-        "@types/string-hash": "^1.1.1",
-        "string-hash": "^1.1.3"
-    },
     "files": [
         "package.json",
         "README.md",


### PR DESCRIPTION
It is unmaintained, 10 lines of code and miss-licensed. It also removes any
installation steps and the need for extra typings.

I replaced it with the same string hashing as Java uses (converted to typescript).