### PR TITLE
buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+steps:
+  - name: "tslint"
+    command: docker-compose run app npm run tslint
+  - wait
+  - name: "compile"
+    branches: "!master"
+    command: docker-compose run app npm run prepack
+  - wait
+  - name: "publish"
+    branches: "master"
+    command: docker-compose run app npm publish

--- a/.buildkite/project.json
+++ b/.buildkite/project.json
@@ -1,0 +1,10 @@
+{
+  "name": "collection-utils",
+  "steps": [
+    {
+      "type": "script",
+      "name": ":pipeline:",
+      "command": "buildkite-agent pipeline upload"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8
+
+RUN mkdir /app
+WORKDIR /app
+
+ENV PATH /app/node_modules/.bin:$PATH
+
+ADD package.json /app/
+RUN npm install
+
+ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,2 @@
+app:
+  build: .


### PR DESCRIPTION
Publish won't work because it doesn't have an NPM token yet,
but we'll add that once we deploy the next time.